### PR TITLE
Avoid error from ppx_js_style in exercise 21

### DIFF
--- a/02-exercises/21-reading_sigs/problem.ml
+++ b/02-exercises/21-reading_sigs/problem.ml
@@ -74,7 +74,9 @@ end
 let two = Abstract_type_example.add Abstract_type_example.one Abstract_type_example.one
 let four = Abstract_type_example.to_int (Abstract_type_example.add two two);;
 
-assert (four = 4)
+let%test "Testing four" =
+  Int.(=) 4 four
+;;
 
 module Fraction : sig
   type t


### PR DESCRIPTION
When working through the exercises, I ran into the following error in exercise 21:
```
File "02-exercises/21-reading_sigs/problem.ml", line 77, characters 0-17:           
77 | assert (four = 4)                                                              
     ^^^^^^^^^^^^^^^^^                                                              
Error: Jane Street style: Toplevel expression are not allowed here.
```
I'm not sure if this is an issue with some library I installed previously, but it was easy to avoid it by using a `let%test` block instead.